### PR TITLE
Remove Get, reuse counter value returned by incr operation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GLIDE_NOVENDOR=$(shell glide novendor)
 
 setup:
 	mkdir -p $(GOPATH)/bin
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 
 build-deps:
 	glide install

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -2,8 +2,6 @@ package ratelimit
 
 import (
 	"errors"
-	"strconv"
-
 	"github.com/garyburd/redigo/redis"
 )
 
@@ -40,27 +38,17 @@ func (rl *RateLimit) Run(key string) error {
 	conn.Send("INCR", key)
 	conn.Send("EXPIRE", key, rl.config.WindowInSeconds)
 
-	_, err := conn.Do("EXEC")
+	results, err := redis.Ints(conn.Do("EXEC"))
 	if err != nil {
 		return err
 	}
 
-	value, err := redis.String(conn.Do("GET", key))
-	if err != nil {
-		return err
-	}
-
-	result, err := strconv.Atoi(value)
-	if err != nil {
-		return err
-	}
-
+	result := results[0]
 	if result > rl.config.Attempts {
 		_, err := conn.Do("EXPIRE", key, rl.config.CooldownInSeconds)
 		if err != nil {
 			return err
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
Avoid making an extra Get call to read counter's value, use the incremented value returned by INCR operation.

Testing Strategy: existing tests for rate limit should pass.

```
c.Send("MULTI")
c.Send("INCR", "foo")
c.Send("EXPIRE", "foo", 300)
r, err := c.Do("EXEC")
// prints [1, 1]
// r[0] result of incr operation
// r[1 ] result of expire, 1 if the timeout was set, 0 if key does not exist.
fmt.Println(r) 
```
[Redis-Expire Doc](https://redis.io/commands/expire)
[Redigo-Pipeline Doc](https://godoc.org/github.com/gomodule/redigo/redis#hdr-Pipelining)